### PR TITLE
Update zlib version

### DIFF
--- a/bin/unix/server.sh
+++ b/bin/unix/server.sh
@@ -89,7 +89,7 @@ function nginx_install {
 	# install zlib
 	# apt-get install zlib1g-dev
 	zlib=zlib
-	zlib_version=1.2.8
+	zlib_version=1.2.10
 	zlib_url=http://zlib.net/zlib-$zlib_version.tar.gz
 	download $zlib tar.gz $zlib_url
 


### PR DESCRIPTION
zlib 1.2.8 is no longer available for download. Updated to 1.2.10